### PR TITLE
Fix interest input parsing

### DIFF
--- a/src/features/profile/ProfileEditForm.tsx
+++ b/src/features/profile/ProfileEditForm.tsx
@@ -15,7 +15,10 @@ export default function ProfileEditForm({ profile, onChange, label }: Props) {
         onChange={e =>
           onChange({
             ...profile,
-            interests: e.target.value.split(' ').map(v => v.trim()).filter(Boolean),
+            interests: e.target.value
+              .split(/[ ,·]+/)
+              .map(v => v.trim())
+              .filter(Boolean),
           })
         }
         placeholder={`${label} (콤마로 구분)`}


### PR DESCRIPTION
## Summary
- filter out unwanted bullet character when saving interests

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557526264c832ea1e572ada53563af