### PR TITLE
Remove bullet separators in profile tech list

### DIFF
--- a/src/features/profile/ProfileCardContent.tsx
+++ b/src/features/profile/ProfileCardContent.tsx
@@ -82,7 +82,6 @@ export default function ProfileCardContent({ profile, isDev }: { profile: Profil
               }}
             >
               {tag}
-              {idx !== arr.length - 1 && <span className="mx-1 text-[#888888] font-bold">·</span>}
             </span>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- clean up profile tags so dots do not appear between technologies

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68557773b2f4832e953181e5e302b950