### PR TITLE
Support dev social links

### DIFF
--- a/src/features/profile/ProfileCardContent.tsx
+++ b/src/features/profile/ProfileCardContent.tsx
@@ -55,7 +55,7 @@ export default function ProfileCardContent({ profile, isDev }: { profile: Profil
           </svg>
           <span>{profile.email}</span>
         </a>
-        <SocialLinks colored />
+        <SocialLinks colored isDev={isDev} />
       </div>
 
       <div className="w-full h-px bg-[#393940] my-6" />

--- a/src/features/social/SocialLinks.tsx
+++ b/src/features/social/SocialLinks.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 
-export default function SocialLinks({ colored = false, angle = 0 }: { colored?: boolean; angle?: number }) {
+export default function SocialLinks({ colored = false, isDev = false }: { colored?: boolean; isDev?: boolean }) {
   const [isDarkMode, setIsDarkMode] = useState(false);
 
   useEffect(() => {
@@ -13,8 +13,8 @@ export default function SocialLinks({ colored = false, angle = 0 }: { colored?: 
     return () => match.removeEventListener('change', handler);
   }, []);
 
-  const githubColor = isDarkMode ? '#e4e4e7' : '#3f3f46';  // angle이 360의 배수면 일반인, 아니면 개발자
-  const isNormal = angle % 360 === 0;
+  const githubColor = isDarkMode ? '#e4e4e7' : '#3f3f46';
+  const isNormal = !isDev;
 
   const SNS = [
     {


### PR DESCRIPTION
## Summary
- support dynamic social links depending on card side

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685beac66c6c832e883f0cf483d999fc