### PR TITLE
Add linkable profile interests

### DIFF
--- a/src/features/profile/ProfileCardContent.tsx
+++ b/src/features/profile/ProfileCardContent.tsx
@@ -67,24 +67,31 @@ export default function ProfileCardContent({ profile, isDev }: { profile: Profil
         </div>
         <div className="flex flex-wrap justify-center gap-x-2 gap-y-2">
           {profile.interests
-            .filter(item => {
+            .map(item => {
               if (typeof item === 'string') {
-                return item.trim() !== '';
-              } else if (
+                return { label: item.trim() };
+              }
+              if (
                 typeof item === 'object' &&
                 'label' in item &&
                 typeof item.label === 'string'
               ) {
-                return item.label.trim() !== '';
+                return {
+                  label: item.label.trim(),
+                  url:
+                    'url' in item && typeof item.url === 'string'
+                      ? item.url
+                      : undefined,
+                };
               }
-              return false;
+              return { label: '' };
             })
+            .filter(item => item.label !== '')
             .map((item, idx, arr) => {
-              if (typeof item === 'string') {
-                const label = item.trim();
+              if (!item.url) {
                 return (
                   <span
-                    key={label + idx}
+                    key={item.label + idx}
                     className={`
                       bg-[#e6e6e6] dark:bg-[#323236]
                       text-[#1e1e1e] dark:text-[#E4E4E7]
@@ -95,14 +102,13 @@ export default function ProfileCardContent({ profile, isDev }: { profile: Profil
                     `}
                     style={{ marginRight: idx !== arr.length - 1 ? '6px' : 0 }}
                   >
-                    {label}
+                    {item.label}
                   </span>
                 );
               }
-              const label = item.label.trim();
               return (
                 <a
-                  key={label + idx}
+                  key={item.label + idx}
                   href={item.url}
                   target="_blank"
                   rel="noopener noreferrer"
@@ -116,7 +122,7 @@ export default function ProfileCardContent({ profile, isDev }: { profile: Profil
                   `}
                   style={{ marginRight: idx !== arr.length - 1 ? '6px' : 0 }}
                 >
-                  {label}
+                  {item.label}
                 </a>
               );
             })}

--- a/src/features/profile/ProfileCardContent.tsx
+++ b/src/features/profile/ProfileCardContent.tsx
@@ -66,9 +66,12 @@ export default function ProfileCardContent({ profile, isDev }: { profile: Profil
           {isDev ? "주요 기술" : "관심사·취미"}
         </div>
         <div className="flex flex-wrap justify-center gap-x-2 gap-y-2">
-          {profile.interests.map((tag, idx, arr) => (
-            <span
-              key={tag + idx}
+          {profile.interests.map((item, idx, arr) => (
+            <a
+              key={item.label + idx}
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
               className={`
                 bg-[#e6e6e6] dark:bg-[#323236]
                 text-[#1e1e1e] dark:text-[#E4E4E7]
@@ -81,8 +84,8 @@ export default function ProfileCardContent({ profile, isDev }: { profile: Profil
                 marginRight: idx !== arr.length - 1 ? '6px' : 0,
               }}
             >
-              {tag}
-            </span>
+              {item.label}
+            </a>
           ))}
         </div>
       </div>

--- a/src/features/profile/ProfileCardContent.tsx
+++ b/src/features/profile/ProfileCardContent.tsx
@@ -66,7 +66,9 @@ export default function ProfileCardContent({ profile, isDev }: { profile: Profil
           {isDev ? "주요 기술" : "관심사·취미"}
         </div>
         <div className="flex flex-wrap justify-center gap-x-2 gap-y-2">
-          {profile.interests.map((item, idx, arr) => (
+          {profile.interests
+            .filter(item => item.label.trim())
+            .map((item, idx, arr) => (
             <a
               key={item.label + idx}
               href={item.url}

--- a/src/features/profile/ProfileCardContent.tsx
+++ b/src/features/profile/ProfileCardContent.tsx
@@ -67,7 +67,9 @@ export default function ProfileCardContent({ profile, isDev }: { profile: Profil
         </div>
         <div className="flex flex-wrap justify-center gap-x-2 gap-y-2">
           {profile.interests
-            .filter(item => item.label.trim())
+            .filter(item =>
+              typeof item === 'string' ? item.trim() : item.label.trim(),
+            )
             .map((item, idx, arr) => (
             <a
               key={item.label + idx}

--- a/src/features/profile/ProfileCardContent.tsx
+++ b/src/features/profile/ProfileCardContent.tsx
@@ -67,30 +67,59 @@ export default function ProfileCardContent({ profile, isDev }: { profile: Profil
         </div>
         <div className="flex flex-wrap justify-center gap-x-2 gap-y-2">
           {profile.interests
-            .filter(item =>
-              typeof item === 'string' ? item.trim() : item.label.trim(),
-            )
-            .map((item, idx, arr) => (
-            <a
-              key={item.label + idx}
-              href={item.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={`
-                bg-[#e6e6e6] dark:bg-[#323236]
-                text-[#1e1e1e] dark:text-[#E4E4E7]
-                rounded-full px-4 py-1.5
-                text-[0.95rem] font-semibold tracking-tight
-                shadow-sm border border-[#5a5a5a]
-                flex items-center
-              `}
-              style={{
-                marginRight: idx !== arr.length - 1 ? '6px' : 0,
-              }}
-            >
-              {item.label}
-            </a>
-          ))}
+            .filter(item => {
+              if (typeof item === 'string') {
+                return item.trim() !== '';
+              } else if (
+                typeof item === 'object' &&
+                'label' in item &&
+                typeof item.label === 'string'
+              ) {
+                return item.label.trim() !== '';
+              }
+              return false;
+            })
+            .map((item, idx, arr) => {
+              if (typeof item === 'string') {
+                const label = item.trim();
+                return (
+                  <span
+                    key={label + idx}
+                    className={`
+                      bg-[#e6e6e6] dark:bg-[#323236]
+                      text-[#1e1e1e] dark:text-[#E4E4E7]
+                      rounded-full px-4 py-1.5
+                      text-[0.95rem] font-semibold tracking-tight
+                      shadow-sm border border-[#5a5a5a]
+                      flex items-center
+                    `}
+                    style={{ marginRight: idx !== arr.length - 1 ? '6px' : 0 }}
+                  >
+                    {label}
+                  </span>
+                );
+              }
+              const label = item.label.trim();
+              return (
+                <a
+                  key={label + idx}
+                  href={item.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`
+                    bg-[#e6e6e6] dark:bg-[#323236]
+                    text-[#1e1e1e] dark:text-[#E4E4E7]
+                    rounded-full px-4 py-1.5
+                    text-[0.95rem] font-semibold tracking-tight
+                    shadow-sm border border-[#5a5a5a]
+                    flex items-center
+                  `}
+                  style={{ marginRight: idx !== arr.length - 1 ? '6px' : 0 }}
+                >
+                  {label}
+                </a>
+              );
+            })}
         </div>
       </div>
 

--- a/src/features/profile/ProfileEditForm.tsx
+++ b/src/features/profile/ProfileEditForm.tsx
@@ -7,22 +7,62 @@ type Props = {
 };
 
 export default function ProfileEditForm({ profile, onChange, label }: Props) {
+  const handleAdd = () => {
+    onChange({
+      ...profile,
+      interests: [...profile.interests, { label: '', url: '' }],
+    });
+  };
+
+  const handleRemove = (idx: number) => {
+    const next = profile.interests.filter((_, i) => i !== idx);
+    onChange({ ...profile, interests: next });
+  };
+
+  const handleItemChange = (
+    idx: number,
+    key: 'label' | 'url',
+    value: string,
+  ) => {
+    const next = profile.interests.map((item, i) =>
+      i === idx ? { ...item, [key]: value } : item,
+    );
+    onChange({ ...profile, interests: next });
+  };
+
   return (
     <div className="w-full space-y-4 mt-4">
-      <input
-        className="w-full rounded bg-[#f4f4f4] dark:bg-[#232334] text-[#18181b] dark:text-white p-2 text-sm border border-gray-300 dark:border-gray-600"
-        value={profile.interests.join(' ')}
-        onChange={e =>
-          onChange({
-            ...profile,
-            interests: e.target.value
-              .split(/[ , ]+/)
-              .map(v => v.trim())
-              .filter(Boolean),
-          })
-        }
-        placeholder={`${label} (콤마로 구분)`}
-      />
+      {profile.interests.map((item, idx) => (
+        <div key={idx} className="flex gap-2 items-center">
+          <input
+            className="flex-1 rounded bg-[#f4f4f4] dark:bg-[#232334] text-[#18181b] dark:text-white p-2 text-sm border border-gray-300 dark:border-gray-600"
+            value={item.label}
+            onChange={e => handleItemChange(idx, 'label', e.target.value)}
+            placeholder={label}
+          />
+          <input
+            className="flex-1 rounded bg-[#f4f4f4] dark:bg-[#232334] text-[#18181b] dark:text-white p-2 text-sm border border-gray-300 dark:border-gray-600"
+            value={item.url}
+            onChange={e => handleItemChange(idx, 'url', e.target.value)}
+            placeholder="링크(URL)"
+          />
+          <button
+            type="button"
+            onClick={() => handleRemove(idx)}
+            className="text-red-500 ml-1 text-xs px-2 py-1 rounded hover:bg-red-50 dark:hover:bg-red-900"
+            aria-label="항목 삭제"
+          >
+            ❌
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={handleAdd}
+        className="text-sm px-3 py-1 rounded bg-[#e6e6e6] dark:bg-[#323236] text-[#1e1e1e] dark:text-[#E4E4E7]"
+      >
+        + 항목 추가
+      </button>
       <textarea
         className="w-full rounded bg-[#f4f4f4] dark:bg-[#232334] text-[#18181b] dark:text-white p-2 text-sm border border-gray-300 dark:border-gray-600"
         rows={3}

--- a/src/features/profile/ProfileEditForm.tsx
+++ b/src/features/profile/ProfileEditForm.tsx
@@ -7,18 +7,22 @@ type Props = {
 };
 
 export default function ProfileEditForm({ profile, onChange, label }: Props) {
+  const interests = profile.interests.map(item =>
+    typeof item === 'string' ? { label: item, url: '' } : item,
+  );
+
   const handleAdd = () => {
-    if (profile.interests.some(item => !item.label.trim() && !item.url.trim())) {
+    if (interests.some(item => !item.label.trim() && !item.url.trim())) {
       return;
     }
     onChange({
       ...profile,
-      interests: [...profile.interests, { label: '', url: '' }],
+      interests: [...interests, { label: '', url: '' }],
     });
   };
 
   const handleRemove = (idx: number) => {
-    const next = profile.interests.filter((_, i) => i !== idx);
+    const next = interests.filter((_, i) => i !== idx);
     onChange({ ...profile, interests: next });
   };
 
@@ -27,24 +31,24 @@ export default function ProfileEditForm({ profile, onChange, label }: Props) {
     key: 'label' | 'url',
     value: string,
   ) => {
-    const next = profile.interests.map((item, i) =>
+    const next = interests.map((item, i) =>
       i === idx ? { ...item, [key]: value } : item,
     );
     onChange({ ...profile, interests: next });
   };
 
   const handleBlur = (idx: number) => {
-    const next = profile.interests.filter(
+    const next = interests.filter(
       (item, i) => !(i === idx && !item.label.trim() && !item.url.trim()),
     );
-    if (next.length !== profile.interests.length) {
+    if (next.length !== interests.length) {
       onChange({ ...profile, interests: next });
     }
   };
 
   return (
     <div className="w-full space-y-4 mt-4">
-      {profile.interests.map((item, idx) => (
+      {interests.map((item, idx) => (
         <div key={idx} className="flex gap-2 items-center">
           <input
             className="flex-1 rounded bg-[#f4f4f4] dark:bg-[#232334] text-[#18181b] dark:text-white p-2 text-sm border border-gray-300 dark:border-gray-600"

--- a/src/features/profile/ProfileEditForm.tsx
+++ b/src/features/profile/ProfileEditForm.tsx
@@ -8,6 +8,9 @@ type Props = {
 
 export default function ProfileEditForm({ profile, onChange, label }: Props) {
   const handleAdd = () => {
+    if (profile.interests.some(item => !item.label.trim() && !item.url.trim())) {
+      return;
+    }
     onChange({
       ...profile,
       interests: [...profile.interests, { label: '', url: '' }],
@@ -30,6 +33,15 @@ export default function ProfileEditForm({ profile, onChange, label }: Props) {
     onChange({ ...profile, interests: next });
   };
 
+  const handleBlur = (idx: number) => {
+    const next = profile.interests.filter(
+      (item, i) => !(i === idx && !item.label.trim() && !item.url.trim()),
+    );
+    if (next.length !== profile.interests.length) {
+      onChange({ ...profile, interests: next });
+    }
+  };
+
   return (
     <div className="w-full space-y-4 mt-4">
       {profile.interests.map((item, idx) => (
@@ -39,12 +51,14 @@ export default function ProfileEditForm({ profile, onChange, label }: Props) {
             value={item.label}
             onChange={e => handleItemChange(idx, 'label', e.target.value)}
             placeholder={label}
+            onBlur={() => handleBlur(idx)}
           />
           <input
             className="flex-1 rounded bg-[#f4f4f4] dark:bg-[#232334] text-[#18181b] dark:text-white p-2 text-sm border border-gray-300 dark:border-gray-600"
             value={item.url}
             onChange={e => handleItemChange(idx, 'url', e.target.value)}
             placeholder="링크(URL)"
+            onBlur={() => handleBlur(idx)}
           />
           <button
             type="button"

--- a/src/features/profile/profile.model.ts
+++ b/src/features/profile/profile.model.ts
@@ -1,12 +1,16 @@
+export type Interest =
+  | string
+  | {
+      label: string;
+      url: string;
+    };
+
 export type Profile = {
   name: string;
   tagline: string;
   email: string;
   photo: string;
-  interests: {
-    label: string;
-    url: string;
-  }[];
+  interests: Interest[];
   intro: string[];
   region: string;
 };

--- a/src/features/profile/profile.model.ts
+++ b/src/features/profile/profile.model.ts
@@ -3,7 +3,10 @@ export type Profile = {
   tagline: string;
   email: string;
   photo: string;
-  interests: string[];
+  interests: {
+    label: string;
+    url: string;
+  }[];
   intro: string[];
   region: string;
 };


### PR DESCRIPTION
## Summary
- enhance profile data model to store interest text and URLs
- allow adding/removing interests with labels and links in the edit form
- make interests clickable in the profile card

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685fd109bb7c832e92ee4fe61c600810