### PR TITLE
Add prompt input toggle on login page

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,42 +1,29 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/AuthProvider";
-import PromptBox from "@/features/prompt/PromptBox";
 
 export const dynamic = "force-dynamic";
 
 export default function LoginPage() {
   const { login, user } = useAuth();
   const router = useRouter();
-  const [showPrompt, setShowPrompt] = useState(false);
 
   useEffect(() => {
     if (user) router.replace("/dashboard");
   }, [user, router]);
 
   return (
-    <>
-      <main className="flex flex-col items-center justify-center gap-4 mt-20 pb-32">
-        <div className="flex gap-4">
-          <button
-            className="bg-blue-500 text-white px-4 py-2 rounded"
-            onClick={async () => {
-              await login();
-              router.push("/dashboard");
-            }}
-          >
-            Login with Google
-          </button>
-          <button
-            className="bg-gray-200 text-gray-700 px-4 py-2 rounded"
-            onClick={() => setShowPrompt(!showPrompt)}
-          >
-            Prompt
-          </button>
-        </div>
-      </main>
-      <PromptBox open={showPrompt} />
-    </>
+    <main className="flex flex-col items-center justify-center gap-4 mt-20">
+      <button
+        className="bg-blue-500 text-white px-4 py-2 rounded"
+        onClick={async () => {
+          await login();
+          router.push("/dashboard");
+        }}
+      >
+        Login with Google
+      </button>
+    </main>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,29 +1,42 @@
 "use client";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/AuthProvider";
+import PromptBox from "@/features/prompt/PromptBox";
 
 export const dynamic = "force-dynamic";
 
 export default function LoginPage() {
   const { login, user } = useAuth();
   const router = useRouter();
+  const [showPrompt, setShowPrompt] = useState(false);
 
   useEffect(() => {
     if (user) router.replace("/dashboard");
   }, [user, router]);
 
   return (
-    <main className="flex flex-col items-center justify-center gap-4 mt-20">
-      <button
-        className="bg-blue-500 text-white px-4 py-2 rounded"
-        onClick={async () => {
-          await login();
-          router.push("/dashboard");
-        }}
-      >
-        Login with Google
-      </button>
-    </main>
+    <>
+      <main className="flex flex-col items-center justify-center gap-4 mt-20 pb-32">
+        <div className="flex gap-4">
+          <button
+            className="bg-blue-500 text-white px-4 py-2 rounded"
+            onClick={async () => {
+              await login();
+              router.push("/dashboard");
+            }}
+          >
+            Login with Google
+          </button>
+          <button
+            className="bg-gray-200 text-gray-700 px-4 py-2 rounded"
+            onClick={() => setShowPrompt(!showPrompt)}
+          >
+            Prompt
+          </button>
+        </div>
+      </main>
+      <PromptBox open={showPrompt} />
+    </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import CommentSection from '@/features/comments/CommentSection';
 import VisitorCount from '@/features/visitors/VisitorCount';
 import FlippableProfileCard from '@/features/profile/FlippableProfileCard';
 import AuthButton from '@/features/auth/AuthButton';
+import PromptBox from '@/features/prompt/PromptBox';
 
 export const dynamic = "force-dynamic";
 
@@ -12,17 +13,26 @@ export default function Home() {
   const [showComments, setShowComments] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
   const [angle, setAngle] = useState(0);
+  const [showPrompt, setShowPrompt] = useState(false);
 
   return (
-    <main className="max-w-xl mx-auto p-6 text-center pb-24">
-      <div className="mb-4 flex justify-end bg-blue-50 dark:bg-gray-800/40 p-2 rounded-md">
-        <a
-          href="/login"
-          className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium border border-blue-300 rounded-full bg-white text-blue-700 hover:bg-blue-100 transition"
-        >
-          <span>🔑</span> <span>Sign In</span>
-        </a>
-      </div>
+    <>
+      <main className="max-w-xl mx-auto p-6 text-center pb-32">
+        <div className="mb-4 flex justify-end items-center gap-2 bg-blue-50 dark:bg-gray-800/40 p-2 rounded-md">
+          <a
+            href="/login"
+            className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium border border-blue-300 rounded-full bg-white text-blue-700 hover:bg-blue-100 transition"
+          >
+            <span>🔑</span> <span>Sign In</span>
+          </a>
+          <button
+            type="button"
+            onClick={() => setShowPrompt(!showPrompt)}
+            className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium border border-blue-300 rounded-full bg-white text-blue-700 hover:bg-blue-100 transition"
+          >
+            <span>💬</span> <span>Prompt</span>
+          </button>
+        </div>
       {/* 설정 버튼은 각도 1000도 이상일 때만 표시 */}
       {angle >= 1000 && <AuthButton onAdminChange={setIsAdmin} visible />}
 
@@ -53,5 +63,7 @@ export default function Home() {
         </div>
       )}
     </main>
+    <PromptBox open={showPrompt} />
+    </>
   );
 }

--- a/src/features/prompt/PromptBox.tsx
+++ b/src/features/prompt/PromptBox.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useState } from "react";
+
+export default function PromptBox({ open }: { open: boolean }) {
+  const [text, setText] = useState("");
+
+  return (
+    <div
+      className={`fixed bottom-0 left-0 w-full bg-white dark:bg-gray-800 border-t border-gray-300 dark:border-gray-700 p-4 transition-transform duration-300 z-40 ${open ? "translate-y-0" : "translate-y-full pointer-events-none"}`}
+    >
+      <div className="max-w-xl mx-auto flex gap-2">
+        <input
+          type="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Type your prompt"
+          className="flex-1 border border-gray-300 dark:border-gray-600 rounded px-3 py-2 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200"
+        />
+        <button
+          type="button"
+          className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new `PromptBox` component fixed to the bottom of the viewport
- add a toggle button next to the login button
- keep main content padded so it isn't hidden

## Testing
- `npm run lint`
- `npm run build` *(fails: Firebase auth config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6860c17fdd44832e945b01bb83b37bbd