### PR TITLE
Add TopBar with icon dropdowns

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -27,4 +27,5 @@
   "language": "Language",
   "wrongPassword": "Incorrect password.",
   "profilePhoto": "profile photo"
+  ,"viewProfile": "View Profile"
 }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -27,5 +27,7 @@
   "language": "Language",
   "wrongPassword": "Incorrect password.",
   "profilePhoto": "profile photo"
+  ,"feedbackMessage": "Thank you for visiting! Please leave a quick opinion and feedback in the comments."
+  ,"goToComments": "Go to Comments"
   ,"viewProfile": "View Profile"
 }

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -27,5 +27,7 @@
   "language": "언어",
   "wrongPassword": "비밀번호가 올바르지 않습니다.",
   "profilePhoto": "프로필 사진"
+  ,"feedbackMessage": "방문해 주셔서 감사합니다! 댓글로 간단한 의견과 피드백을 남겨 주세요."
+  ,"goToComments": "댓글 남기기"
   ,"viewProfile": "프로필 보기"
 }

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -27,4 +27,5 @@
   "language": "언어",
   "wrongPassword": "비밀번호가 올바르지 않습니다.",
   "profilePhoto": "프로필 사진"
+  ,"viewProfile": "프로필 보기"
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import AuthProvider from "@/lib/AuthProvider";
 import I18nProvider from "@/lib/I18nProvider";
-import LanguageSwitcher from "@/features/lang/LanguageSwitcher";
+import TopBar from "@/features/nav/TopBar";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -19,9 +19,7 @@ export default function RootLayout({
       <body className="antialiased relative">
         <AuthProvider>
           <I18nProvider>
-            <div className="fixed top-2 right-4 z-50">
-              <LanguageSwitcher />
-            </div>
+            <TopBar />
             {children}
           </I18nProvider>
         </AuthProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,8 +6,6 @@ import CommentSection from '@/features/comments/CommentSection';
 import VisitorCount from '@/features/visitors/VisitorCount';
 import FlippableProfileCard from '@/features/profile/FlippableProfileCard';
 import AuthButton from '@/features/auth/AuthButton';
-import PromptBox from '@/features/prompt/PromptBox';
-import AuthStatus from '@/features/auth/AuthStatus';
 
 export const dynamic = "force-dynamic";
 
@@ -15,22 +13,12 @@ export default function Home() {
   const [showComments, setShowComments] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
   const [angle, setAngle] = useState(0);
-  const [showPrompt, setShowPrompt] = useState(false);
   const { t } = useTranslation();
 
   return (
     <>
       <main className="max-w-xl mx-auto p-6 text-center pb-32">
-        <div className="mb-4 flex justify-end items-center gap-2 bg-blue-50 dark:bg-gray-800/40 p-2 rounded-md">
-          <AuthStatus />
-          <button
-            type="button"
-            onClick={() => setShowPrompt(!showPrompt)}
-            className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium border border-blue-300 rounded-full bg-white text-blue-700 hover:bg-blue-100 transition"
-          >
-            <span>💬</span> <span>{t('prompt')}</span>
-          </button>
-        </div>
+        {/* Top actions removed in favor of global menu */}
       {/* 설정 버튼은 각도 1000도 이상일 때만 표시 */}
       {angle >= 1000 && <AuthButton onAdminChange={setIsAdmin} visible />}
 
@@ -61,7 +49,6 @@ export default function Home() {
         </div>
       )}
     </main>
-    <PromptBox open={showPrompt} />
     </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import CommentSection from '@/features/comments/CommentSection';
 import VisitorCount from '@/features/visitors/VisitorCount';
 import FlippableProfileCard from '@/features/profile/FlippableProfileCard';
 import AuthButton from '@/features/auth/AuthButton';
+import FeedbackBanner from '@/features/feedback/FeedbackBanner';
 
 export const dynamic = "force-dynamic";
 
@@ -44,11 +45,12 @@ export default function Home() {
 
       {/* 댓글 영역 */}
       {showComments && (
-        <div className="w-full flex flex-col items-center">
+        <div id="comments" className="w-full flex flex-col items-center">
           <CommentSection isAdmin={isAdmin} />
         </div>
       )}
     </main>
+    <FeedbackBanner onShowComments={() => setShowComments(true)} />
     </>
   );
 }

--- a/src/features/feedback/FeedbackBanner.tsx
+++ b/src/features/feedback/FeedbackBanner.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'next-i18next'
+
+export default function FeedbackBanner({ onShowComments }: { onShowComments: () => void }) {
+  const { t } = useTranslation()
+  const [visible, setVisible] = useState(false)
+  const [startY, setStartY] = useState<number | null>(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (sessionStorage.getItem('hideFeedbackBanner') === '1') return
+    const timer = setTimeout(() => setVisible(true), 10000)
+    return () => clearTimeout(timer)
+  }, [])
+
+  const hide = () => {
+    setVisible(false)
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem('hideFeedbackBanner', '1')
+    }
+  }
+
+  if (!visible) return null
+
+  return (
+    <div
+      onTouchStart={(e) => setStartY(e.touches[0].clientY)}
+      onTouchMove={(e) => {
+        if (startY !== null && e.touches[0].clientY - startY > 50) hide()
+      }}
+      className="fixed bottom-4 left-1/2 -translate-x-1/2 w-[calc(100%-1rem)] max-w-md bg-white/80 dark:bg-gray-800/80 backdrop-blur border border-gray-300 dark:border-gray-700 rounded-lg p-4 shadow z-50"
+    >
+      <button
+        type="button"
+        aria-label="close"
+        onClick={hide}
+        className="absolute top-1 right-2 text-lg font-bold"
+      >
+        ×
+      </button>
+      <p className="mb-2 text-sm">{t('feedbackMessage')}</p>
+      <div className="text-right">
+        <button
+          type="button"
+          onClick={() => {
+            onShowComments()
+            hide()
+          }}
+          className="px-3 py-1 text-sm rounded bg-blue-500 text-white hover:bg-blue-600"
+        >
+          {t('goToComments')}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/features/feedback/FeedbackBanner.tsx
+++ b/src/features/feedback/FeedbackBanner.tsx
@@ -32,14 +32,6 @@ export default function FeedbackBanner({ onShowComments }: { onShowComments: () 
       }}
       className="fixed bottom-4 left-1/2 -translate-x-1/2 w-[calc(100%-1rem)] max-w-md bg-white/80 dark:bg-gray-800/80 backdrop-blur border border-gray-300 dark:border-gray-700 rounded-lg p-4 shadow z-50"
     >
-      <button
-        type="button"
-        aria-label="close"
-        onClick={hide}
-        className="absolute top-1 right-2 text-lg font-bold"
-      >
-        ×
-      </button>
       <p className="mb-2 text-sm">{t('feedbackMessage')}</p>
       <div className="text-right">
         <button

--- a/src/features/nav/TopBar.tsx
+++ b/src/features/nav/TopBar.tsx
@@ -1,134 +1,106 @@
-'use client';
+'use client'
 
-import { useState } from 'react';
-import Image from 'next/image';
-import Link from 'next/link';
-import { useTranslation } from 'next-i18next';
-import { useAuth } from '@/lib/AuthProvider';
-import i18n from '@/lib/i18n';
+import { useState } from 'react'
+import Link from 'next/link'
+import { useTranslation } from 'next-i18next'
+import { useAuth } from '@/lib/AuthProvider'
+import i18n from '@/lib/i18n'
+import PromptBox from '@/features/prompt/PromptBox'
 
 const LANGS = [
   { code: 'ko', label: '🇰🇷' },
   { code: 'en', label: '🇺🇸' },
-];
+]
 
 export default function TopBar() {
-  const { user, logout, login } = useAuth();
-  const { t } = useTranslation();
-  const [langOpen, setLangOpen] = useState(false);
-  const [profileOpen, setProfileOpen] = useState(false);
-  const [logoutOpen, setLogoutOpen] = useState(false);
+  const { user, login, logout } = useAuth()
+  const { t } = useTranslation()
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [promptOpen, setPromptOpen] = useState(false)
 
   const changeLanguage = (l: string) => {
-    if (!i18n) return;
-    i18n.changeLanguage(l);
-    document.documentElement.lang = l;
-    localStorage.setItem('lang', l);
-    setLangOpen(false);
-  };
+    if (!i18n) return
+    i18n.changeLanguage(l)
+    document.documentElement.lang = l
+    localStorage.setItem('lang', l)
+  }
+
+  const togglePrompt = () => {
+    setPromptOpen((v) => !v)
+    setMenuOpen(false)
+  }
 
   return (
-    <div className="fixed top-2 right-4 z-50 flex gap-1 p-1 rounded-full backdrop-blur bg-white/50 dark:bg-gray-800/50 shadow border border-gray-300 dark:border-gray-700">
-      {/* Language */}
-      <div className="relative">
-        <button
-          type="button"
-          aria-label={t('language')}
-          onClick={() => setLangOpen(!langOpen)}
-          className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-200/70 dark:hover:bg-gray-700/60"
-        >
-          🌐
-        </button>
-        {langOpen && (
-          <div className="absolute right-0 mt-2 bg-white/80 dark:bg-gray-800/80 backdrop-blur border border-gray-300 dark:border-gray-700 rounded-lg shadow text-sm overflow-hidden">
-            {LANGS.map(l => (
+    <>
+      <div className="fixed top-2 right-4 z-50">
+        <div className="relative">
+          <button
+            type="button"
+            aria-label="menu"
+            onClick={() => setMenuOpen(!menuOpen)}
+            className="w-10 h-10 flex items-center justify-center rounded-full backdrop-blur bg-white/60 dark:bg-gray-800/60 shadow border border-gray-300 dark:border-gray-700 hover:bg-gray-200/70 dark:hover:bg-gray-700/60"
+          >
+            <span className="text-xl">···</span>
+          </button>
+          {menuOpen && (
+            <div className="absolute right-0 mt-2 w-48 bg-white/80 dark:bg-gray-800/80 backdrop-blur border border-gray-300 dark:border-gray-700 rounded-lg shadow text-sm">
               <button
-                key={l.code}
-                onClick={() => changeLanguage(l.code)}
-                className="block w-full text-left px-3 py-1 hover:bg-gray-100 dark:hover:bg-gray-700"
+                onClick={togglePrompt}
+                className="block w-full text-left px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
               >
-                {l.label}
+                {t('prompt')}
               </button>
-            ))}
-          </div>
-        )}
+              {!user && (
+                <button
+                  onClick={() => {
+                    login()
+                    setMenuOpen(false)
+                  }}
+                  className="block w-full text-left px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                >
+                  {t('signIn')}
+                </button>
+              )}
+              {user && (
+                <>
+                  <Link
+                    href="/dashboard"
+                    onClick={() => setMenuOpen(false)}
+                    className="block px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                  >
+                    {t('viewProfile')}
+                  </Link>
+                  <button
+                    onClick={() => {
+                      logout()
+                      setMenuOpen(false)
+                    }}
+                    className="block w-full text-left px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                  >
+                    {t('logout')}
+                  </button>
+                </>
+              )}
+              <div className="border-t border-gray-200 dark:border-gray-700 px-3 py-2 flex items-center gap-2">
+                <span className="mr-auto">{t('language')}</span>
+                {LANGS.map((l) => (
+                  <button
+                    key={l.code}
+                    onClick={() => {
+                      changeLanguage(l.code)
+                      setMenuOpen(false)
+                    }}
+                    className="px-1 hover:underline"
+                  >
+                    {l.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
       </div>
-
-      {/* Logout Icon */}
-      {user && (
-        <div className="relative">
-          <button
-            type="button"
-            aria-label={t('logout')}
-            onClick={() => setLogoutOpen(!logoutOpen)}
-            className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-200/70 dark:hover:bg-gray-700/60"
-          >
-            🔓
-          </button>
-          {logoutOpen && (
-            <div className="absolute right-0 mt-2 bg-white/80 dark:bg-gray-800/80 backdrop-blur border border-gray-300 dark:border-gray-700 rounded-lg shadow p-2 text-sm">
-              <div className="mb-2">{t('confirm')}</div>
-              <div className="flex gap-2">
-                <button
-                  onClick={() => { logout(); setLogoutOpen(false); }}
-                  className="flex-1 px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
-                >
-                  {t('logout')}
-                </button>
-                <button
-                  onClick={() => setLogoutOpen(false)}
-                  className="flex-1 px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
-                >
-                  {t('cancel')}
-                </button>
-              </div>
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Profile Icon */}
-      {user ? (
-        <div className="relative">
-          <button
-            type="button"
-            aria-label={t('profilePhoto')}
-            onClick={() => setProfileOpen(!profileOpen)}
-            className="w-8 h-8 flex items-center justify-center rounded-full overflow-hidden hover:bg-gray-200/70 dark:hover:bg-gray-700/60"
-          >
-            {user.photoURL ? (
-              <Image src={user.photoURL} alt={t('profilePhoto')} width={32} height={32} className="rounded-full" />
-            ) : (
-              <span className="text-xl">👤</span>
-            )}
-          </button>
-          {profileOpen && (
-            <div className="absolute right-0 mt-2 w-48 bg-white/80 dark:bg-gray-800/80 backdrop-blur border border-gray-300 dark:border-gray-700 rounded-lg shadow p-3 text-sm">
-              <div className="mb-2 font-medium truncate">
-                {user.displayName || user.email}
-              </div>
-              <Link href="/dashboard" className="block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700">
-                {t('viewProfile')}
-              </Link>
-              <button
-                onClick={() => { logout(); setProfileOpen(false); }}
-                className="block w-full text-left px-2 py-1 mt-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
-              >
-                {t('logout')}
-              </button>
-            </div>
-          )}
-        </div>
-      ) : (
-        <button
-          type="button"
-          onClick={login}
-          aria-label={t('signIn')}
-          className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-200/70 dark:hover:bg-gray-700/60"
-        >
-          🔑
-        </button>
-      )}
-    </div>
-  );
+      <PromptBox open={promptOpen} />
+    </>
+  )
 }

--- a/src/features/nav/TopBar.tsx
+++ b/src/features/nav/TopBar.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useTranslation } from 'next-i18next';
+import { useAuth } from '@/lib/AuthProvider';
+import i18n from '@/lib/i18n';
+
+const LANGS = [
+  { code: 'ko', label: '🇰🇷' },
+  { code: 'en', label: '🇺🇸' },
+];
+
+export default function TopBar() {
+  const { user, logout, login } = useAuth();
+  const { t } = useTranslation();
+  const [langOpen, setLangOpen] = useState(false);
+  const [profileOpen, setProfileOpen] = useState(false);
+  const [logoutOpen, setLogoutOpen] = useState(false);
+
+  const changeLanguage = (l: string) => {
+    if (!i18n) return;
+    i18n.changeLanguage(l);
+    document.documentElement.lang = l;
+    localStorage.setItem('lang', l);
+    setLangOpen(false);
+  };
+
+  return (
+    <div className="fixed top-2 right-4 z-50 flex gap-1 p-1 rounded-full backdrop-blur bg-white/50 dark:bg-gray-800/50 shadow border border-gray-300 dark:border-gray-700">
+      {/* Language */}
+      <div className="relative">
+        <button
+          type="button"
+          aria-label={t('language')}
+          onClick={() => setLangOpen(!langOpen)}
+          className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-200/70 dark:hover:bg-gray-700/60"
+        >
+          🌐
+        </button>
+        {langOpen && (
+          <div className="absolute right-0 mt-2 bg-white/80 dark:bg-gray-800/80 backdrop-blur border border-gray-300 dark:border-gray-700 rounded-lg shadow text-sm overflow-hidden">
+            {LANGS.map(l => (
+              <button
+                key={l.code}
+                onClick={() => changeLanguage(l.code)}
+                className="block w-full text-left px-3 py-1 hover:bg-gray-100 dark:hover:bg-gray-700"
+              >
+                {l.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Logout Icon */}
+      {user && (
+        <div className="relative">
+          <button
+            type="button"
+            aria-label={t('logout')}
+            onClick={() => setLogoutOpen(!logoutOpen)}
+            className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-200/70 dark:hover:bg-gray-700/60"
+          >
+            🔓
+          </button>
+          {logoutOpen && (
+            <div className="absolute right-0 mt-2 bg-white/80 dark:bg-gray-800/80 backdrop-blur border border-gray-300 dark:border-gray-700 rounded-lg shadow p-2 text-sm">
+              <div className="mb-2">{t('confirm')}</div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => { logout(); setLogoutOpen(false); }}
+                  className="flex-1 px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+                >
+                  {t('logout')}
+                </button>
+                <button
+                  onClick={() => setLogoutOpen(false)}
+                  className="flex-1 px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+                >
+                  {t('cancel')}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Profile Icon */}
+      {user ? (
+        <div className="relative">
+          <button
+            type="button"
+            aria-label={t('profilePhoto')}
+            onClick={() => setProfileOpen(!profileOpen)}
+            className="w-8 h-8 flex items-center justify-center rounded-full overflow-hidden hover:bg-gray-200/70 dark:hover:bg-gray-700/60"
+          >
+            {user.photoURL ? (
+              <Image src={user.photoURL} alt={t('profilePhoto')} width={32} height={32} className="rounded-full" />
+            ) : (
+              <span className="text-xl">👤</span>
+            )}
+          </button>
+          {profileOpen && (
+            <div className="absolute right-0 mt-2 w-48 bg-white/80 dark:bg-gray-800/80 backdrop-blur border border-gray-300 dark:border-gray-700 rounded-lg shadow p-3 text-sm">
+              <div className="mb-2 font-medium truncate">
+                {user.displayName || user.email}
+              </div>
+              <Link href="/dashboard" className="block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700">
+                {t('viewProfile')}
+              </Link>
+              <button
+                onClick={() => { logout(); setProfileOpen(false); }}
+                className="block w-full text-left px-2 py-1 mt-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+              >
+                {t('logout')}
+              </button>
+            </div>
+          )}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={login}
+          aria-label={t('signIn')}
+          className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-200/70 dark:hover:bg-gray-700/60"
+        >
+          🔑
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/features/profile/FlippableProfileCard.tsx
+++ b/src/features/profile/FlippableProfileCard.tsx
@@ -77,7 +77,7 @@ export default function FlippableProfileCard({ isAdmin = false, onAngleChange }:
 
   return (
     <section
-      className="max-w-[600px] mx-auto mt-20 mb-8 px-2 relative select-none z-10"
+      className="max-w-[600px] mx-auto mt-10 mb-8 px-2 relative select-none z-10"
       style={{ perspective: 1200, overflow: 'visible', touchAction: 'pan-y' }}
       {...pointerHandlers}
       ref={containerRef}


### PR DESCRIPTION
## Summary
- create `TopBar` component with language, logout, and profile icon menus
- add `viewProfile` translations
- use `TopBar` in the root layout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861fce43d54832e9891531d0a235746