### PR TITLE
Improve chat styling

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -38,4 +38,5 @@
   "remaining": "Questions left: {{count}}",
   "typing": "typing",
   "noQuestionsLeft": "No questions left. Please try again tomorrow."
+  ,"aiDisclaimer": "AI may occasionally provide inaccurate or misleading information."
 }

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -38,4 +38,5 @@
   "remaining": "残りの質問数: {{count}}",
   "typing": "入力中",
   "noQuestionsLeft": "残りの質問回数がありません。明日またお試しください。"
+  ,"aiDisclaimer": "AI が不正確または誤解を招く情報を提供する場合があります。"
 }

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -38,4 +38,5 @@
   "remaining": "남은 질문 횟수: {{count}}",
   "typing": "작성 중",
   "noQuestionsLeft": "남은 질문 횟수가 없습니다. 내일 다시 시도하세요."
+  ,"aiDisclaimer": "AI가 부정확하거나 오해의 소지가 있는 정보를 제공할 수 있습니다."
 }

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -38,4 +38,5 @@
   "remaining": "剩余问题数: {{count}}",
   "typing": "输入中",
   "noQuestionsLeft": "已无剩余提问次数，请明天再试。"
+  ,"aiDisclaimer": "AI 可能偶尔会提供不准确或具有误导性的信息。"
 }

--- a/src/features/comments/CommentItem.tsx
+++ b/src/features/comments/CommentItem.tsx
@@ -9,7 +9,7 @@ export default function CommentItem({ text, date, onDelete, isAdmin }: Props) {
   return (
     <li className="border border-[color:var(--border)] bg-card p-3 rounded-lg flex justify-between items-start shadow-sm">
       <div className="flex-1 min-w-0">
-        <div className="break-words text-base text-[color:var(--foreground)]">{text}</div>
+        <div className="break-normal whitespace-pre-wrap text-base text-[color:var(--foreground)]">{text}</div>
         <div className="text-xs text-muted mt-1">{date}</div>
       </div>
       {isAdmin && (

--- a/src/features/comments/CommentItem.tsx
+++ b/src/features/comments/CommentItem.tsx
@@ -9,7 +9,7 @@ export default function CommentItem({ text, date, onDelete, isAdmin }: Props) {
   return (
     <li className="border border-[color:var(--border)] bg-card p-3 rounded-lg flex justify-between items-start shadow-sm">
       <div className="flex-1 min-w-0">
-        <div className="break-normal whitespace-pre-wrap text-base text-[color:var(--foreground)]">{text}</div>
+        <div className="break-keep whitespace-pre-wrap text-base text-[color:var(--foreground)]">{text}</div>
         <div className="text-xs text-muted mt-1">{date}</div>
       </div>
       {isAdmin && (

--- a/src/features/profile/ProfileCardContent.tsx
+++ b/src/features/profile/ProfileCardContent.tsx
@@ -137,7 +137,7 @@ export default function ProfileCardContent({ profile, isDev }: { profile: Profil
         <div className="text-[1rem] font-bold tracking-tight text-[#1e1e1e] dark:text-[#E4E4E7] mb-2">{t('introduction')}</div>
         <div className="space-y-4 text-[#2c2c2c] dark:text-[#C4C4C8] text-[1.05rem] leading-7 font-medium">
           {profile.intro.map((p, i) => (
-            <p key={i}>{p}</p>
+            <p key={i} className="break-normal whitespace-pre-wrap">{p}</p>
           ))}
         </div>
       </div>

--- a/src/features/profile/ProfileCardContent.tsx
+++ b/src/features/profile/ProfileCardContent.tsx
@@ -137,7 +137,7 @@ export default function ProfileCardContent({ profile, isDev }: { profile: Profil
         <div className="text-[1rem] font-bold tracking-tight text-[#1e1e1e] dark:text-[#E4E4E7] mb-2">{t('introduction')}</div>
         <div className="space-y-4 text-[#2c2c2c] dark:text-[#C4C4C8] text-[1.05rem] leading-7 font-medium">
           {profile.intro.map((p, i) => (
-            <p key={i} className="break-normal whitespace-pre-wrap">{p}</p>
+            <p key={i} className="break-keep whitespace-pre-wrap">{p}</p>
           ))}
         </div>
       </div>

--- a/src/features/prompt/PromptBox.tsx
+++ b/src/features/prompt/PromptBox.tsx
@@ -105,7 +105,7 @@ export default function PromptBox({
             {messages.map((m, i) => (
               <div key={i} className="space-y-1">
                 <div
-                  className={`text-sm leading-relaxed break-words whitespace-pre-wrap max-w-[75%] px-3 py-2 rounded-md ${
+                  className={`text-sm leading-relaxed break-normal whitespace-pre-wrap max-w-[75%] px-3 py-2 rounded-md ${
                     m.role === 'user'
                       ? 'ml-auto bg-blue-500 text-white'
                       : 'mr-auto bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
@@ -116,7 +116,7 @@ export default function PromptBox({
               </div>
             ))}
             {loading && (
-              <div className="text-sm leading-relaxed break-words whitespace-pre-wrap max-w-[75%] mr-auto bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 rounded-md">
+              <div className="text-sm leading-relaxed break-normal whitespace-pre-wrap max-w-[75%] mr-auto bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 rounded-md">
                 {t('typing')}
                 {'.'.repeat(dots)}
               </div>
@@ -155,6 +155,7 @@ export default function PromptBox({
         {showLimit && (
           <p className="text-xs text-red-600">{t('max30Chars')}</p>
         )}
+        <p className="text-xs text-gray-400 text-center">AI may occasionally provide inaccurate or misleading information.</p>
       </div>
     </div>
   );

--- a/src/features/prompt/PromptBox.tsx
+++ b/src/features/prompt/PromptBox.tsx
@@ -105,7 +105,7 @@ export default function PromptBox({
             {messages.map((m, i) => (
               <div key={i} className="space-y-1">
                 <div
-                  className={`text-sm leading-relaxed break-normal whitespace-pre-wrap max-w-[75%] px-3 py-2 rounded-md ${
+                  className={`text-sm leading-relaxed break-keep whitespace-pre-wrap max-w-[75%] px-3 py-2 rounded-md ${
                     m.role === 'user'
                       ? 'ml-auto bg-blue-500 text-white'
                       : 'mr-auto bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
@@ -116,7 +116,7 @@ export default function PromptBox({
               </div>
             ))}
             {loading && (
-              <div className="text-sm leading-relaxed break-normal whitespace-pre-wrap max-w-[75%] mr-auto bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 rounded-md">
+              <div className="text-sm leading-relaxed break-keep whitespace-pre-wrap max-w-[75%] mr-auto bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 rounded-md">
                 {t('typing')}
                 {'.'.repeat(dots)}
               </div>

--- a/src/features/prompt/PromptBox.tsx
+++ b/src/features/prompt/PromptBox.tsx
@@ -155,8 +155,8 @@ export default function PromptBox({
         {showLimit && (
           <p className="text-xs text-red-600">{t('max30Chars')}</p>
         )}
-        <p className="text-xs text-gray-400 text-center">AI may occasionally provide inaccurate or misleading information.</p>
+          <p className="text-xs text-gray-400 text-center">{t('aiDisclaimer')}</p>
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  }


### PR DESCRIPTION
## Summary
- prevent words from breaking mid-word in chat and comments
- add disclaimer to chat

## Testing
- `npm run lint`
- `npm run build` *(fails: FirebaseError: auth/invalid-api-key)*

------
https://chatgpt.com/codex/tasks/task_e_687235635a7c832e85fa6df02734359c