### PR TITLE
Store prompts to Firestore

### DIFF
--- a/src/features/prompt/PromptBox.tsx
+++ b/src/features/prompt/PromptBox.tsx
@@ -25,8 +25,6 @@ export default function PromptBox({
     const prompt = text.trim();
     if (!prompt) return;
     setMessages((m) => [...m, { role: "user", text: prompt }]);
-    // Save prompt text to Firestore
-    void savePrompt(prompt);
     setText("");
     setLoading(true);
     try {
@@ -39,6 +37,7 @@ export default function PromptBox({
       const reply = data.reply || data.text;
       if (reply) {
         setMessages((m) => [...m, { role: "assistant", text: reply }]);
+        void savePrompt(prompt, reply);
       }
       if (typeof data.remaining === "number") {
         setRemaining(data.remaining);

--- a/src/features/prompt/PromptBox.tsx
+++ b/src/features/prompt/PromptBox.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "next-i18next";
+import { savePrompt } from "./prompt.api";
 
 export default function PromptBox({
   open,
@@ -24,6 +25,8 @@ export default function PromptBox({
     const prompt = text.trim();
     if (!prompt) return;
     setMessages((m) => [...m, { role: "user", text: prompt }]);
+    // Save prompt text to Firestore
+    void savePrompt(prompt);
     setText("");
     setLoading(true);
     try {

--- a/src/features/prompt/prompt.api.ts
+++ b/src/features/prompt/prompt.api.ts
@@ -1,10 +1,11 @@
 import { collection, addDoc, Timestamp } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
 
-export async function savePrompt(text: string) {
+export async function savePrompt(prompt: string, reply: string) {
   try {
     await addDoc(collection(db, 'prompts'), {
-      text,
+      prompt,
+      reply,
       createdAt: Timestamp.now(),
     })
   } catch (err) {

--- a/src/features/prompt/prompt.api.ts
+++ b/src/features/prompt/prompt.api.ts
@@ -1,0 +1,13 @@
+import { collection, addDoc, Timestamp } from 'firebase/firestore'
+import { db } from '@/lib/firebase'
+
+export async function savePrompt(text: string) {
+  try {
+    await addDoc(collection(db, 'prompts'), {
+      text,
+      createdAt: Timestamp.now(),
+    })
+  } catch (err) {
+    console.error('Failed to save prompt:', err)
+  }
+}


### PR DESCRIPTION
## Summary
- log prompt submissions to Firestore
- expose a helper to add prompts

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687333991dec832eb1f72c4374d03a76