### PR TITLE
Fix word wrapping in feedback banner and invite button

### DIFF
--- a/src/features/feedback/FeedbackBanner.tsx
+++ b/src/features/feedback/FeedbackBanner.tsx
@@ -39,7 +39,7 @@ export default function FeedbackBanner({
       }}
       className="fixed top-4 right-4 w-80 max-w-[calc(100%-2rem)] bg-white/70 dark:bg-gray-800/70 backdrop-blur-md border border-gray-200 dark:border-gray-600 rounded-xl p-3 shadow z-50"
     >
-      <p className="mb-2 text-sm leading-relaxed">{t('feedbackMessage')}</p>
+      <p className="mb-2 text-sm leading-relaxed break-keep whitespace-pre-wrap">{t('feedbackMessage')}</p>
       <div className="text-right">
         <button
           type="button"

--- a/src/features/nav/TopBar.tsx
+++ b/src/features/nav/TopBar.tsx
@@ -136,7 +136,7 @@ export default function TopBar() {
             setPromptOpen(true)
             setInviteVisible(false)
           }}
-          className="fixed bottom-20 left-1/2 -translate-x-1/2 z-40 px-6 py-2 rounded-[24px] bg-[#357AE8] text-white text-sm leading-[1.4] shadow transition-transform hover:shadow-lg hover:scale-105 flex items-center"
+          className="fixed bottom-20 left-1/2 -translate-x-1/2 z-40 px-6 py-2 rounded-[24px] bg-[#357AE8] text-white text-sm leading-[1.4] shadow transition-transform hover:shadow-lg hover:scale-105 flex items-center break-keep whitespace-pre-wrap"
         >
           <span className="mr-1.5" aria-hidden>🚀</span>
           {t('chatInvite')}


### PR DESCRIPTION
## Summary
- ensure text in the feedback banner wraps at word boundaries
- prevent single-character wrapping in chat invite button

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873c04dd398832eb08f87899e096af8