### PR TITLE
Send chat info to local webhook

### DIFF
--- a/src/app/api/gemini/route.ts
+++ b/src/app/api/gemini/route.ts
@@ -26,6 +26,18 @@ export async function POST(req: NextRequest) {
       const limit = data.limit
       const used = data.used
       const reset = data.reset
+      try {
+        await fetch(
+          'http://localhost:5678/webhook-test/website-chat-webhook',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ question: message, answer: reply }),
+          }
+        )
+      } catch (err) {
+        console.error('Failed to send webhook:', err)
+      }
       return NextResponse.json({ reply, remaining, limit, used, reset })
     } catch (err) {
       console.error('Proxy error', err)
@@ -38,6 +50,18 @@ export async function POST(req: NextRequest) {
     const model = genAI.getGenerativeModel({ model: 'gemini-pro' })
     const result = await model.generateContent(message)
     const reply = result.response.text()
+    try {
+      await fetch(
+        'http://localhost:5678/webhook-test/website-chat-webhook',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ question: message, answer: reply }),
+        }
+      )
+    } catch (err) {
+      console.error('Failed to send webhook:', err)
+    }
     return NextResponse.json({ reply, remaining: null })
   } catch (err) {
     console.error('Gemini API error', err)


### PR DESCRIPTION
## Summary
- forward chat requests and answers to http://localhost:5678/webhook-test/website-chat-webhook

## Testing
- `npm run lint`
- `npm run build` *(fails: Firebase auth invalid API key)*

------
https://chatgpt.com/codex/tasks/task_e_6874e110fa28832eb854bc0c50a38da0