### PR TITLE
Redesign profile cards

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,20 +1,21 @@
 @import "tailwindcss";
 
 :root {
-  --background: #f9fafb;
-  --foreground: #171717;
-  --primary: #2563eb;
-  --primary-contrast: #fff;
-  --card-bg: #fff;
-  --border: #e5e7eb;
-  --input-bg: #fff;
-  --input-border: #cbd5e1;
+  --background: linear-gradient(135deg, #0f172a, #1e3a8a);
+  --foreground: #f1f5f9;
+  --primary: #60a5fa;
+  --primary-contrast: #0f172a;
+  --card-bg: rgba(255, 255, 255, 0.05);
+  --border: rgba(255, 255, 255, 0.2);
+  --input-bg: rgba(255, 255, 255, 0.08);
+  --input-border: rgba(255, 255, 255, 0.2);
   --button-bg: #2563eb;
   --button-hover: #1d4ed8;
   --button-text: #fff;
-  --muted: #64748b;
+  --muted: #94a3b8;
   --font-geist-sans: system-ui, sans-serif;
   --font-geist-mono: ui-monospace, monospace;
+  --font-sans: 'Inter', 'Pretendard', var(--font-geist-sans);
 }
 
 /* @theme inline {
@@ -24,22 +25,6 @@
   --font-mono: var(--font-geist-mono);
 } */
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #18181b;
-    --foreground: #ededed;
-    --primary: #60a5fa;
-    --primary-contrast: #18181b;
-    --card-bg: #232329;
-    --border: #2d2d35;
-    --input-bg: #232329;
-    --input-border: #374151;
-    --button-bg: #2563eb;
-    --button-hover: #1e40af;
-    --button-text: #fff;
-    --muted: #a1a1aa;
-  }
-}
 
 body {
   background: var(--background);
@@ -59,7 +44,7 @@ button, input, textarea {
 }
 
 button {
-  transition: background 0.2s, color 0.2s;
+  transition: background 0.2s, color 0.2s, box-shadow 0.2s;
   cursor: pointer;
   min-height: 44px;
   min-width: 44px;
@@ -70,6 +55,7 @@ button {
 
 button:hover, button:focus {
   background: var(--button-hover);
+  box-shadow: 0 0 8px var(--primary);
 }
 
 input, textarea {
@@ -80,18 +66,25 @@ input, textarea {
   font-size: 1rem;
   background: var(--input-bg);
   color: var(--foreground);
-  transition: border 0.2s, background 0.2s;
+  transition: border 0.2s, background 0.2s, box-shadow 0.2s;
 }
 
 input:focus, textarea:focus {
   border-color: var(--primary);
+  box-shadow: 0 0 6px var(--primary);
 }
 
 .card, .bg-card {
   background: var(--card-bg);
   color: var(--foreground);
-  border-radius: 16px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  border-radius: 20px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.25);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+}
+
+.glass-card {
+  @apply card p-6;
 }
 
 .text-muted {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from "next";
+import { Inter } from "next/font/google";
 import "./globals.css";
 import AuthProvider from "@/lib/AuthProvider";
 import I18nProvider from "@/lib/I18nProvider";
 import TopBar from "@/features/nav/TopBar";
+
+const inter = Inter({ subsets: ["latin"], display: "swap" });
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -15,7 +18,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning className={inter.className}>
       <body className="antialiased relative">
         <AuthProvider>
           <I18nProvider>

--- a/src/features/profile/ProfileCardContent.tsx
+++ b/src/features/profile/ProfileCardContent.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Profile } from './profile.model';
 import SocialLinks from '@/features/social/SocialLinks';
 import { useTranslation } from 'next-i18next';
@@ -5,147 +6,96 @@ import Image from 'next/image';
 
 export default function ProfileCardContent({ profile, isDev }: { profile: Profile; isDev: boolean }) {
   const { t } = useTranslation();
+  const [tab, setTab] = useState<'interests' | 'intro'>('interests');
+
+  const interests = profile.interests
+    .map(item => (typeof item === 'string' ? { label: item.trim() } : { label: item.label.trim(), url: item.url }))
+    .filter(item => item.label !== '');
+
   return (
-    <div
-      className={`
-        w-full
-        bg-[#27272A] dark:bg-[#27272A]
-        rounded-[28px]
-        border-[3px] border-[#5a5a5a]
-        shadow-[0_8px_36px_0_rgba(0,0,0,0.3),0_2px_10px_0_rgba(0,0,0,0.15)]
-        p-8 sm:p-10 flex flex-col items-center
-        transition-transform duration-300
-        group
-        hover:scale-[1.02]
-        will-change-transform
-      `}
-      style={{
-        background: "var(--card-bg, #27272A)",
-        minHeight: 480,
-        color: "var(--foreground, #1e1e1e)", // 진한 텍스트 색 (라이트 모드용)
-      }}
-    >
-      <div className="mb-4">
-        <Image
-          src={profile.photo}
-          alt={t('profilePhoto', { defaultValue: 'profile photo' })}
-          width={144}
-          height={144}
-          className={`
-            rounded-full border-[6px] border-[color:var(--primary)]
-            object-cover shadow-lg
-            transition-transform duration-300
-            group-hover:scale-105
-          `}
-          style={{ background: "var(--background)" }}
-        />
-      </div>
-
-      <div className="text-[2.1rem] font-extrabold tracking-tight text-[#1e1e1e] dark:text-[#E4E4E7] mb-2">
-        {profile.name}
-      </div>
-
-      <div className="text-[1.25rem] text-[#2c2c2c] dark:text-[#A1A1AA] font-semibold tracking-tight mb-3">
-        {profile.tagline}
-      </div>
-
-      <div className="flex items-center justify-center gap-4 mb-6 flex-wrap">
+    <div className="w-full space-y-6">
+      <div className="glass-card text-center flex flex-col items-center">
+        <div className="mb-4">
+          <Image
+            src={profile.photo}
+            alt={t('profilePhoto', { defaultValue: 'profile photo' })}
+            width={144}
+            height={144}
+            className="rounded-full border-[6px] border-[color:var(--primary)] object-cover shadow-lg"
+            style={{ background: 'var(--background)' }}
+          />
+        </div>
+        <div className="text-2xl font-extrabold tracking-tight mb-1">{profile.name}</div>
+        <div className="text-lg font-semibold text-muted mb-2">{profile.tagline}</div>
         <a
           href={`mailto:${profile.email}`}
-          className="flex items-center gap-1.5 text-[#2c2c2c] dark:text-[#A1A1AA] hover:text-[color:var(--primary)] transition-colors text-base font-medium"
+          className="inline-flex items-center gap-1.5 hover:text-[color:var(--primary)] transition-colors text-sm font-medium"
         >
           <svg width="20" height="20" fill="currentColor" aria-hidden="true">
             <rect width="20" height="20" rx="4" fill="none" />
-            <path d="M3 5.5A2.5 2.5 0 0 1 5.5 3h9A2.5 2.5 0 0 1 17 5.5v9A2.5 2.5 0 0 1 14.5 17h-9A2.5 2.5 0 0 1 3 14.5v-9Zm2.2.5 4.3 3.7a1 1 0 0 0 1.3 0l4.3-3.7" stroke="currentColor" strokeWidth="1.2" fill="none"/>
+            <path d="M3 5.5A2.5 2.5 0 0 1 5.5 3h9A2.5 2.5 0 0 1 17 5.5v9A2.5 2.5 0 0 1 14.5 17h-9A2.5 2.5 0 0 1 3 14.5v-9Zm2.2.5 4.3 3.7a1 1 0 0 0 1.3 0l4.3-3.7" stroke="currentColor" strokeWidth="1.2" fill="none" />
           </svg>
           <span>{profile.email}</span>
         </a>
-        <SocialLinks colored isDev={isDev} />
+        <div className="mt-4 text-sm font-semibold flex items-center justify-center">
+          <span className="mr-1" aria-hidden>📍</span>
+          {t('region')}: {profile.region}
+        </div>
       </div>
 
-      <div className="w-full h-px bg-[#393940] my-6" />
-
-      {/* 관심사 또는 기술 */}
-      <div className="w-full text-center mb-6">
-        <div className="text-[1rem] font-bold tracking-tight text-[#1e1e1e] dark:text-[#E4E4E7] mb-2">
-          {isDev ? t('mainSkills') : t('hobbies')}
+      <div className="glass-card">
+        <div className="flex justify-center mb-4 gap-2">
+          <button
+            type="button"
+            onClick={() => setTab('interests')}
+            className={`px-3 py-1 rounded-full text-sm font-semibold ${tab === 'interests' ? 'bg-blue-600 text-white' : 'bg-white/10'}`}
+          >
+            {isDev ? t('mainSkills') : t('hobbies')}
+          </button>
+          <button
+            type="button"
+            onClick={() => setTab('intro')}
+            className={`px-3 py-1 rounded-full text-sm font-semibold ${tab === 'intro' ? 'bg-blue-600 text-white' : 'bg-white/10'}`}
+          >
+            {t('introduction')}
+          </button>
         </div>
-        <div className="flex flex-wrap justify-center gap-2">
-          {profile.interests
-            .map(item => {
-              if (typeof item === 'string') {
-                return { label: item.trim() };
-              }
-              if (
-                typeof item === 'object' &&
-                'label' in item &&
-                typeof item.label === 'string'
-              ) {
-                return {
-                  label: item.label.trim(),
-                  url:
-                    'url' in item && typeof item.url === 'string'
-                      ? item.url
-                      : undefined,
-                };
-              }
-              return { label: '' };
-            })
-            .filter(item => item.label !== '')
-            .map((item, idx) => {
-              if (!item.url) {
-                return (
-                  <span
-                    key={item.label + idx}
-                    className={`
-                      bg-[#e6e6e6] dark:bg-[#323236]
-                      text-[#1e1e1e]/70 dark:text-[#E4E4E7]/70
-                      rounded-full px-4 py-1.5
-                      text-[0.95rem] font-semibold tracking-tight
-                      shadow-sm border border-[#5a5a5a]
-                      flex items-center cursor-default opacity-60
-                    `}
-                  >
-                    {item.label}
-                  </span>
-                );
-              }
-              return (
+        {tab === 'interests' ? (
+          <div className="flex flex-wrap justify-center gap-2">
+            {interests.map((item, idx) => (
+              item.url ? (
                 <a
                   key={item.label + idx}
                   href={item.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className={`
-                    bg-[#e6e6e6] dark:bg-[#323236]
-                    text-[#1e1e1e] dark:text-[#E4E4E7]
-                    rounded-full px-4 py-1.5
-                    text-[0.95rem] font-semibold tracking-tight
-                    shadow-sm border border-[#5a5a5a]
-                    flex items-center hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors
-                  `}
+                  className="bg-white/20 hover:bg-white/30 rounded-full px-4 py-1.5 text-sm font-semibold"
                 >
                   {item.label}
                 </a>
-              );
-            })}
-        </div>
+              ) : (
+                <span
+                  key={item.label + idx}
+                  className="bg-white/10 rounded-full px-4 py-1.5 text-sm font-semibold text-white/70"
+                >
+                  {item.label}
+                </span>
+              )
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-4 text-sm leading-6 text-center">
+            {profile.intro.map((p, i) => (
+              <p key={i} className="break-keep whitespace-pre-wrap">
+                {p}
+              </p>
+            ))}
+          </div>
+        )}
       </div>
 
-      {/* 소개 */}
-      <div className="w-full text-center mb-6">
-        <div className="text-[1rem] font-bold tracking-tight text-[#1e1e1e] dark:text-[#E4E4E7] mb-2">{t('introduction')}</div>
-        <div className="space-y-4 text-[#2c2c2c] dark:text-[#C4C4C8] text-[1.05rem] leading-7 font-medium">
-          {profile.intro.map((p, i) => (
-            <p key={i} className="break-keep whitespace-pre-wrap">{p}</p>
-          ))}
-        </div>
-      </div>
-
-      {/* 지역 */}
-      <div className="mt-4 text-[0.95rem] flex items-center justify-center text-[#4b4b4b] dark:text-[#B0B0B8] font-semibold tracking-tight">
-        <span className="mr-1" aria-hidden>📍</span>
-        {t('region')}: {profile.region}
+      <div className="glass-card text-center">
+        <SocialLinks colored isDev={isDev} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- apply Inter font to page layout
- switch to a gradient background and glass-like card style
- add glow animations to buttons and inputs
- break profile info into separate glass cards with tabbed content

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6879be2a2dd8832e92b0c860cd6e6c85