### PR TITLE
Redesign AI chat input

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -19,6 +19,7 @@
   "confirm": "Confirm",
   "loginWithGoogle": "Login with Google",
   "typeYourPrompt": "Type your prompt",
+  "promptHint": "Ask the AI anything naturally. E.g., 'Summarize my to-do list', 'Give me blog ideas'",
   "send": "Send",
   "mainSkills": "Main Skills",
   "hobbies": "Interests & Hobbies",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -19,6 +19,7 @@
   "confirm": "確認",
   "loginWithGoogle": "Googleでログイン",
   "typeYourPrompt": "プロンプトを入力してください",
+  "promptHint": "AI に自然な言葉で何でも質問できます。例: 'やることリストを要約して', 'ブログのアイデアを教えて'",
   "send": "送信",
   "mainSkills": "主要スキル",
   "hobbies": "興味・趣味",

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -19,6 +19,7 @@
   "confirm": "확인",
   "loginWithGoogle": "Google로 로그인",
   "typeYourPrompt": "프롬프트를 입력하세요",
+  "promptHint": "AI에게 자연스럽게 무엇이든 물어보세요. 예: '할 일 목록 요약해줘', '블로그 아이디어 알려줘'",
   "send": "전송",
   "mainSkills": "주요 기술",
   "hobbies": "관심사·취미",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -19,6 +19,7 @@
   "confirm": "确认",
   "loginWithGoogle": "使用 Google 登录",
   "typeYourPrompt": "输入您的提示",
+  "promptHint": "可以自然地向 AI 提问，例如：'总结我的待办事项'、'给我博客创意'",
   "send": "发送",
   "mainSkills": "主要技能",
   "hobbies": "兴趣与爱好",

--- a/src/features/prompt/PromptBox.tsx
+++ b/src/features/prompt/PromptBox.tsx
@@ -83,25 +83,25 @@ export default function PromptBox({
 
   return (
     <div
-      className={`fixed bottom-0 left-0 w-full bg-white/70 dark:bg-gray-800/70 backdrop-blur-md border-t border-gray-200 dark:border-gray-600 p-3 transition-transform duration-300 z-40 ${open ? "translate-y-0" : "translate-y-full pointer-events-none"}`}
+      className={`fixed bottom-0 left-0 w-full bg-white/30 dark:bg-gray-900/30 backdrop-blur-lg border-t border-white/30 dark:border-gray-700 px-4 py-3 transition-transform duration-300 z-40 ${open ? "translate-y-0" : "translate-y-full pointer-events-none"}`}
     >
-      <div className="max-w-xl mx-auto flex flex-col gap-2">
-        <div className="flex justify-between items-center">
+      <div className="max-w-xl mx-auto flex flex-col gap-2 relative">
+        <div className="absolute top-2 right-2 flex gap-2">
           <button
             type="button"
             aria-label={collapsed ? t('showConversation') : t('hideConversation')}
             onClick={() => setCollapsed((v) => !v)}
-            className="text-sm px-3 py-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white/40 dark:bg-gray-700/40 hover:bg-gray-100 dark:hover:bg-gray-700"
+            className="p-1 rounded hover:bg-black/10 dark:hover:bg-white/10 text-lg"
           >
-            {collapsed ? t('showConversation') : t('hideConversation')}
+            {collapsed ? '↓' : '↑'}
           </button>
           <button
             type="button"
             onClick={onClose}
             aria-label={t('close')}
-            className="w-8 h-8 flex items-center justify-center rounded-full border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700"
+            className="p-1 rounded hover:bg-black/10 dark:hover:bg-white/10 text-lg"
           >
-            <span className="text-xl leading-none">×</span>
+            ×
           </button>
         </div>
         {!collapsed && (
@@ -130,6 +130,9 @@ export default function PromptBox({
             )}
           </div>
         )}
+        <p className="text-xs text-gray-500 text-center break-keep">
+          {t('promptHint')}
+        </p>
         <div className="flex items-center gap-2">
           <input
             type="text"
@@ -146,14 +149,15 @@ export default function PromptBox({
             }}
             onKeyDown={(e) => e.key === "Enter" && sendPrompt()}
             placeholder={t('typeYourPrompt')}
-            className="flex-1 border border-gray-300 dark:border-gray-500 rounded-md px-3 py-2 bg-white/50 dark:bg-gray-700/40 text-gray-700 dark:text-gray-200 placeholder-gray-500 dark:placeholder-gray-500"
+            className="flex-1 bg-white/30 dark:bg-gray-700/30 backdrop-blur-sm border border-white/30 dark:border-gray-600/40 rounded-md px-3 py-2 shadow-inner text-gray-700 dark:text-gray-200 placeholder-gray-500 dark:placeholder-gray-500"
           />
         <button
           type="button"
           onClick={sendPrompt}
-          className="bg-blue-500/80 hover:bg-blue-600 text-white text-sm px-3 py-2 rounded-md"
+          aria-label={t('send')}
+          className="p-2 rounded-full bg-blue-500/80 hover:bg-blue-600 text-white"
         >
-          {t('send')}
+          ➤
         </button>
         </div>
         {remaining !== null && (
@@ -162,7 +166,7 @@ export default function PromptBox({
         {showLimit && (
           <p className="text-xs text-red-600">{t('max30Chars')}</p>
         )}
-          <p className="text-xs text-gray-400 text-center">{t('aiDisclaimer')}</p>
+          <p className="text-xs text-gray-400 text-center break-keep">{t('aiDisclaimer')}</p>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- restyle prompt box with glassmorphic look and icon buttons
- add hint explaining prompts
- add localized prompt hint strings

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6879c49f178c832e8611db738043f5bd