### PR TITLE
Fix icon metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,9 @@ import TopBar from "@/features/nav/TopBar";
 export const metadata: Metadata = {
   title: "yeojoonsoo02",
   description: "yeojoonsoo02",
+  icons: {
+    icon: "/favicon.ico?v=1",
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- add metadata icons for favicon with cache-busting query string

## Testing
- `npm run lint`
- `npm run build` *(fails: Firebase auth invalid-api-key)*

------
https://chatgpt.com/codex/tasks/task_e_687c704b07b4832eafe7c1b8efb9dc6d