### PR TITLE
Update Korean prompt placeholder

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -18,7 +18,7 @@
   "cancel": "Cancel",
   "confirm": "Confirm",
   "loginWithGoogle": "Login with Google",
-  "typeYourPrompt": "Type your prompt",
+  "typeYourPrompt": "Ask the AI",
   "send": "Send",
   "mainSkills": "Main Skills",
   "hobbies": "Interests & Hobbies",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -18,7 +18,7 @@
   "cancel": "キャンセル",
   "confirm": "確認",
   "loginWithGoogle": "Googleでログイン",
-  "typeYourPrompt": "プロンプトを入力してください",
+  "typeYourPrompt": "AI に質問してください",
   "send": "送信",
   "mainSkills": "主要スキル",
   "hobbies": "興味・趣味",

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -18,7 +18,7 @@
   "cancel": "취소",
   "confirm": "확인",
   "loginWithGoogle": "Google로 로그인",
-  "typeYourPrompt": "프롬프트를 입력하세요",
+  "typeYourPrompt": "AI에게 질문하세요",
   "send": "전송",
   "mainSkills": "주요 기술",
   "hobbies": "관심사·취미",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -18,7 +18,7 @@
   "cancel": "取消",
   "confirm": "确认",
   "loginWithGoogle": "使用 Google 登录",
-  "typeYourPrompt": "输入您的提示",
+  "typeYourPrompt": "向 AI 提问",
   "send": "发送",
   "mainSkills": "主要技能",
   "hobbies": "兴趣与爱好",


### PR DESCRIPTION
## Summary
- update translations for the prompt placeholder across languages

## Testing
- `npm run lint`
- `npm run build` *(fails: Firebase auth invalid-api-key)*

------
https://chatgpt.com/codex/tasks/task_e_687dcf81b388832eba96a14dec6ad6ed